### PR TITLE
Connection Lists from urls

### DIFF
--- a/McTools.Xrm.Connection.WinForms/ConnectionSelector.cs
+++ b/McTools.Xrm.Connection.WinForms/ConnectionSelector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Windows.Forms;
 using System.Xml;
 
@@ -95,6 +96,13 @@ namespace McTools.Xrm.Connection.WinForms
                 lvConnections.Groups.AddRange(groups);
                 lvConnections.EndUpdate();
             }
+
+            tsbNewConnection.Enabled = !ConnectionManager.Instance.ConnectionsList.IsReadOnly;
+            tsbUpdateConnection.Enabled = !ConnectionManager.Instance.ConnectionsList.IsReadOnly;
+            tsbCloneConnection.Enabled = !ConnectionManager.Instance.ConnectionsList.IsReadOnly;
+            tsbDeleteConnection.Enabled = !ConnectionManager.Instance.ConnectionsList.IsReadOnly;
+            tsbUpdatePassword.Enabled = !ConnectionManager.Instance.ConnectionsList.IsReadOnly;
+            tsb_UseMru.Enabled = !ConnectionManager.Instance.ConnectionsList.IsReadOnly;
         }
 
         private void LoadConnectionFile()
@@ -181,7 +189,7 @@ namespace McTools.Xrm.Connection.WinForms
             {
                 BValidateClick(sender, e);
             }
-            else
+            else if (!ConnectionManager.Instance.ConnectionsList.IsReadOnly)
             {
                 tsbUpdateConnection_Click(sender, null);
             }
@@ -224,7 +232,7 @@ namespace McTools.Xrm.Connection.WinForms
                     {
                         indexToSelect = index;
                     }
-                    else
+                    else if (!Uri.IsWellFormedUriString(file.Path, UriKind.Absolute))
                     {
                         tsbMoveToExistingFile.DropDownItems.Add(new ToolStripButton
                         {
@@ -246,7 +254,7 @@ namespace McTools.Xrm.Connection.WinForms
             tscbbConnectionsFile.SelectedIndex = indexToSelect;
             tscbbConnectionsFile.SelectedIndexChanged += tscbbConnectionsFile_SelectedIndexChanged;
 
-            if (tscbbConnectionsFile.SelectedItem != null && !File.Exists(((ConnectionFile)tscbbConnectionsFile.SelectedItem).Path))
+            if (tscbbConnectionsFile.SelectedItem != null && !ConnectionManager.FileExists(((ConnectionFile)tscbbConnectionsFile.SelectedItem).Path))
             {
                 CleanFileList((ConnectionFile)tscbbConnectionsFile.SelectedItem);
                 return;
@@ -396,7 +404,7 @@ namespace McTools.Xrm.Connection.WinForms
             }
             else
             {
-                if (!File.Exists(connectionFile.Path))
+                if (!ConnectionManager.FileExists(connectionFile.Path))
                 {
                     CleanFileList(connectionFile);
                     return;
@@ -414,7 +422,7 @@ namespace McTools.Xrm.Connection.WinForms
                 tsbMoveToExistingFile.DropDownItems.Clear();
                 foreach (var file in ConnectionsList.Instance.Files.OrderBy(k => k.Name))
                 {
-                    if (connectionFile.Path == file.Path)
+                    if (connectionFile.Path == file.Path || Uri.IsWellFormedUriString(file.Path, UriKind.Absolute))
                     {
                         continue;
                     }

--- a/McTools.Xrm.Connection.WinForms/CrmConnectionStatusBar.cs
+++ b/McTools.Xrm.Connection.WinForms/CrmConnectionStatusBar.cs
@@ -229,7 +229,7 @@ namespace McTools.Xrm.Connection.WinForms
                                 "McTools.Xrm.Connection.WinForms.Resources.server.png");
                     }
 
-                    BuildActionItems(item);
+                    BuildActionItems(item, connections.IsReadOnly);
                     if (!mergeConnectionFiles && filesCount > 1)
                     {
                         fileItem.DropDownItems.Add(item);
@@ -248,14 +248,17 @@ namespace McTools.Xrm.Connection.WinForms
                     }
                 }
 
-                var newConnectionItem = new ToolStripMenuItem();
-                newConnectionItem.Text = "Create new connection";
-                newConnectionItem.Image = (Image)resources.GetObject("server_add");
-                newConnectionItem.Click += newConnectionItem_Click;
-
-                if (!mergeConnectionFiles && filesCount > 1)
+                if (!connections.IsReadOnly)
                 {
-                    fileItem.DropDownItems.Add(newConnectionItem);
+                    var newConnectionItem = new ToolStripMenuItem();
+                    newConnectionItem.Text = "Create new connection";
+                    newConnectionItem.Image = (Image)resources.GetObject("server_add");
+                    newConnectionItem.Click += newConnectionItem_Click;
+
+                    if (!mergeConnectionFiles && filesCount > 1)
+                    {
+                        fileItem.DropDownItems.Add(newConnectionItem);
+                    }
                 }
             }
 
@@ -293,7 +296,8 @@ namespace McTools.Xrm.Connection.WinForms
         /// Creates the three action menus for a connection
         /// </summary>
         /// <param name="item">Menu where to add the actions</param>
-        private void BuildActionItems(ToolStripMenuItem item)
+        /// <param name="readOnly">Indicates if the connection is from a read-only list</param>
+        private void BuildActionItems(ToolStripMenuItem item, bool readOnly)
         {
             ToolStripMenuItem cItem = new ToolStripMenuItem();
             cItem.Click += actionItem_Click;
@@ -301,17 +305,20 @@ namespace McTools.Xrm.Connection.WinForms
             cItem.Image = (Image)resources.GetObject("server_connect");
             item.DropDownItems.Add(cItem);
 
-            ToolStripMenuItem eItem = new ToolStripMenuItem();
-            eItem.Click += actionItem_Click;
-            eItem.Text = "Edit";
-            eItem.Image = (Image)resources.GetObject("server_edit");
-            item.DropDownItems.Add(eItem);
+            if (!readOnly)
+            {
+                ToolStripMenuItem eItem = new ToolStripMenuItem();
+                eItem.Click += actionItem_Click;
+                eItem.Text = "Edit";
+                eItem.Image = (Image)resources.GetObject("server_edit");
+                item.DropDownItems.Add(eItem);
 
-            ToolStripMenuItem dItem = new ToolStripMenuItem();
-            dItem.Click += actionItem_Click;
-            dItem.Text = "Delete";
-            dItem.Image = (Image)resources.GetObject("server_delete");
-            item.DropDownItems.Add(dItem);
+                ToolStripMenuItem dItem = new ToolStripMenuItem();
+                dItem.Click += actionItem_Click;
+                dItem.Text = "Delete";
+                dItem.Image = (Image)resources.GetObject("server_delete");
+                item.DropDownItems.Add(dItem);
+            }
         }
 
         /// <summary>
@@ -430,7 +437,7 @@ namespace McTools.Xrm.Connection.WinForms
                             "McTools.Xrm.Connection.WinForms.Resources.server.png");
                 }
 
-                BuildActionItems(item);
+                BuildActionItems(item, false);
 
                 if (parentItem.DropDownItems.Count == 1)
                 {

--- a/McTools.Xrm.Connection/ConnectionManager.cs
+++ b/McTools.Xrm.Connection/ConnectionManager.cs
@@ -158,6 +158,9 @@ namespace McTools.Xrm.Connection
                 fsw.Dispose();
             }
 
+            if (Uri.IsWellFormedUriString(ConfigurationFile, UriKind.Absolute))
+                return;
+
             var path = new FileInfo(ConfigurationFile).Directory.FullName;
 
             if (Directory.Exists(path))
@@ -277,7 +280,7 @@ namespace McTools.Xrm.Connection
             try
             {
                 CrmConnections crmConnections;
-                if (File.Exists(ConfigurationFile))
+                if (FileExists(ConfigurationFile))
                 {
                     crmConnections = CrmConnections.LoadFromFile(ConfigurationFile);
 
@@ -330,6 +333,33 @@ namespace McTools.Xrm.Connection
                 throw new Exception("Error while deserializing configuration file. Details: " + error.Message);
             }
         }
+
+        /// <summary>
+        /// Checks if a configuration file exists
+        /// </summary>
+        /// <param name="path">The file to check for</param>
+        /// <returns><c>true</c> if the <paramref name="path"/> exists, or <c>false</c> otherwise</returns>
+        public static bool FileExists(string path)
+        {
+            if (Uri.IsWellFormedUriString(path, UriKind.Absolute))
+            {
+                try
+                {
+                    var req = WebRequest.Create(path);
+                    using (req.GetResponse())
+                    {
+                        return true;
+                    }
+                }
+                catch (WebException)
+                {
+                    return false;
+                }
+            }
+
+            return File.Exists(path);
+        }
+
 
         /// <summary>
         /// Saves Crm connections list to file

--- a/McTools.Xrm.Connection/ConnectionManager.cs
+++ b/McTools.Xrm.Connection/ConnectionManager.cs
@@ -346,6 +346,7 @@ namespace McTools.Xrm.Connection
                 try
                 {
                     var req = WebRequest.Create(path);
+                    req.Credentials = CredentialCache.DefaultCredentials;
                     using (req.GetResponse())
                     {
                         return true;

--- a/McTools.Xrm.Connection/CrmConnections.cs
+++ b/McTools.Xrm.Connection/CrmConnections.cs
@@ -261,7 +261,7 @@ namespace McTools.Xrm.Connection
                     cd.UseMfa = useMfaElement != null && useMfaElement.Value == "true";
 
                     var userDomainElement = elt.Element("UserDomain");
-                    if (timeOutElement != null)
+                    if (userDomainElement != null)
                     {
                         cd.UserDomain = userDomainElement.Value;
                     }
@@ -348,6 +348,7 @@ namespace McTools.Xrm.Connection
             if (Uri.IsWellFormedUriString(filePath, UriKind.Absolute))
             {
                 var req = WebRequest.Create(filePath);
+                req.Credentials = CredentialCache.DefaultCredentials;
                 var resp = req.GetResponse();
                 return resp.GetResponseStream();
             }


### PR DESCRIPTION
This PR allows connection lists to be loaded from arbitrary URLs rather than just files, with some restrictions.

Use case for this is that we have a central list of D365 connection details that we want to share among a team and manage centrally, but need to apply various dynamic changes to that list such as filtering it based on who is accessing the list. A simple way for us to do this is with an Intranet site that dynamically generates the connection list XML based on the requesting user.

This change decides whether to use `File` or `WebRequest` to load the XML based on whether the file name presented is a well-formed URI. If it is a URI, all options to make changes to the connection list are disabled.