### PR TITLE
Issue #93 FormHelper requires to use a Window Form object, update to accept Control

### DIFF
--- a/McTools.Xrm.Connection.WinForms/FormHelper.cs
+++ b/McTools.Xrm.Connection.WinForms/FormHelper.cs
@@ -7,9 +7,9 @@ namespace McTools.Xrm.Connection.WinForms
 {
     public class FormHelper
     {
-        private readonly ContainerControl innerAppForm;
+        private readonly IWin32Window innerAppForm;
 
-        public FormHelper(ContainerControl innerAppForm)
+        public FormHelper(IWin32Window innerAppForm)
         {
             this.innerAppForm = innerAppForm;
         }

--- a/McTools.Xrm.Connection.WinForms/FormHelper.cs
+++ b/McTools.Xrm.Connection.WinForms/FormHelper.cs
@@ -7,9 +7,9 @@ namespace McTools.Xrm.Connection.WinForms
 {
     public class FormHelper
     {
-        private readonly Form innerAppForm;
+        private readonly ContainerControl innerAppForm;
 
-        public FormHelper(Form innerAppForm)
+        public FormHelper(ContainerControl innerAppForm)
         {
             this.innerAppForm = innerAppForm;
         }

--- a/McTools.Xrm.Connection.WinForms/FormHelper.cs
+++ b/McTools.Xrm.Connection.WinForms/FormHelper.cs
@@ -7,9 +7,9 @@ namespace McTools.Xrm.Connection.WinForms
 {
     public class FormHelper
     {
-        private readonly IWin32Window innerAppForm;
+        private readonly Control innerAppForm;
 
-        public FormHelper(IWin32Window innerAppForm)
+        public FormHelper(Control innerAppForm)
         {
             this.innerAppForm = innerAppForm;
         }


### PR DESCRIPTION
updated the FormHelper class to accept an instance of a Control object instead of Form.  This will allow the use of this project where a Window Form is not available, but a UserControl is.  

Resolves https://github.com/MscrmTools/MscrmTools.Xrm.Connection/issues/93