### PR TITLE
Store service client created via SDK login control for later reuse

### DIFF
--- a/McTools.Xrm.Connection/ConnectionManager.cs
+++ b/McTools.Xrm.Connection/ConnectionManager.cs
@@ -593,6 +593,8 @@ namespace McTools.Xrm.Connection
 
         public void ConnectToServerWithSdkLoginCtrl(ConnectionDetail detail, CrmServiceClient crmSvc, object connectionParameter)
         {
+            detail.ServiceClient = crmSvc;
+
             var parameters = new List<object> { detail, connectionParameter, 1 };
 
             if (crmSvc.IsReady)


### PR DESCRIPTION
Tools that attempt to use the `ServiceClient` property of a connection that uses the SDK login control get an error "Unable to read user password", as it attempts to reconnect using a username and password.

This change stores the service client created by the SDK login control in the ConnectionDetail instance so that it can be accessed again later.

I believe this will address https://github.com/MscrmTools/XrmToolBox/issues/882