### PR TITLE
OAuth fixes

### DIFF
--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -464,8 +464,8 @@ namespace McTools.Xrm.Connection
                      ConnectionManager.CryptoInitVector,
                      ConnectionManager.CryptoKeySize);
 
-                var cachePath = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, "oauth-cache.txt");
-                crmSvc = new CrmServiceClient(new Uri($"https://{ServerName}:{ServerPort}"), AzureAdAppId.ToString(), CrmServiceClient.MakeSecureString(secret), true, cachePath);
+                var path = Path.Combine(Path.GetTempPath(), ConnectionId.Value.ToString("B"), "oauth-cache.txt");
+                crmSvc = new CrmServiceClient(new Uri($"https://{ServerName}:{ServerPort}"), AzureAdAppId.ToString(), CrmServiceClient.MakeSecureString(secret), true, path);
             }
         }
 

--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xrm.Sdk.Client;
+﻿using McTools.Xrm.Connection.Utils;
+using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Discovery;
 using Microsoft.Xrm.Tooling.Connector;
 using System;
@@ -10,6 +11,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Xml.Linq;
 
 namespace McTools.Xrm.Connection
@@ -447,7 +449,24 @@ namespace McTools.Xrm.Connection
 
         private void ConnectOAuth()
         {
-            crmSvc = new CrmServiceClient(new Uri($"https://{ServerName}:{ServerPort}"), AzureAdAppId.ToString(), CrmServiceClient.MakeSecureString(clientSecret), true, "oauth-cache.txt");
+            if (!String.IsNullOrEmpty(RefreshToken))
+            {
+                CrmServiceClient.AuthOverrideHook = new RefreshTokenAuthOverride(this);
+                crmSvc = new CrmServiceClient(new Uri($"https://{ServerName}:{ServerPort}"), true);
+                CrmServiceClient.AuthOverrideHook = null;
+            }
+            else
+            {
+                var secret = CryptoManager.Decrypt(clientSecret, ConnectionManager.CryptoPassPhrase,
+                     ConnectionManager.CryptoSaltValue,
+                     ConnectionManager.CryptoHashAlgorythm,
+                     ConnectionManager.CryptoPasswordIterations,
+                     ConnectionManager.CryptoInitVector,
+                     ConnectionManager.CryptoKeySize);
+
+                var cachePath = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, "oauth-cache.txt");
+                crmSvc = new CrmServiceClient(new Uri($"https://{ServerName}:{ServerPort}"), AzureAdAppId.ToString(), CrmServiceClient.MakeSecureString(secret), true, cachePath);
+            }
         }
 
         private void ConnectOnline()

--- a/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
+++ b/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
@@ -73,7 +73,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>McTools.Xrm.Connection.pfx</AssemblyOriginatorKeyFile>
@@ -160,6 +160,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AutoRefreshSecurityToken.cs" />
     <Compile Include="Utils\ManagedTokenDiscoveryServiceProxy.cs" />
+    <Compile Include="Utils\RefreshTokenAuthOverride.cs" />
     <Compile Include="XmlSerializerHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/McTools.Xrm.Connection/Utils/RefreshTokenAuthOverride.cs
+++ b/McTools.Xrm.Connection/Utils/RefreshTokenAuthOverride.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Web;
+using Microsoft.Xrm.Tooling.Connector;
+using Newtonsoft.Json;
+
+namespace McTools.Xrm.Connection.Utils
+{
+    class RefreshTokenAuthOverride : IOverrideAuthHookWrapper
+    {
+        private readonly ConnectionDetail _connection;
+        private readonly IDictionary<string, Token> _accessTokens;
+
+        class Token
+        {
+            public string access_token;
+            public string refresh_token;
+            public int expires_on;
+        }
+
+        public RefreshTokenAuthOverride(ConnectionDetail connection)
+        {
+            _connection = connection;
+            _accessTokens = new Dictionary<string, Token>();
+        }
+
+        public string GetAuthToken(Uri connectedUri)
+        {
+            if (_accessTokens.TryGetValue(connectedUri.Host, out var token) && new DateTime(1970, 1, 1).AddSeconds(token.expires_on) > DateTimeOffset.Now)
+                return token.access_token;
+
+            _accessTokens[connectedUri.Host] = GetAccessTokenFromAzureAD(connectedUri);
+            return _accessTokens[connectedUri.Host].access_token;
+        }
+
+        private Token GetAccessTokenFromAzureAD(Uri orgUrl)
+        {
+            var secret = CryptoManager.Decrypt(_connection.S2SClientSecret, ConnectionManager.CryptoPassPhrase,
+                 ConnectionManager.CryptoSaltValue,
+                 ConnectionManager.CryptoHashAlgorythm,
+                 ConnectionManager.CryptoPasswordIterations,
+                 ConnectionManager.CryptoInitVector,
+                 ConnectionManager.CryptoKeySize);
+
+            var resource = new Uri(orgUrl, "/");
+
+            var url = "https://login.microsoftonline.com/common/oauth2/token";
+            var data = new Dictionary<string, string>
+            {
+                ["client_id"] = _connection.AzureAdAppId.ToString(),
+                ["client_secret"] = secret,
+                ["resource"] = resource.ToString(),
+                ["grant_type"] = "refresh_token",
+                ["refresh_token"] = _connection.RefreshToken,
+                ["redirect_uri"] = _connection.ReplyUrl
+            };
+
+            var req = WebRequest.Create(url);
+            req.Method = "POST";
+            req.ContentType = "application/x-www-form-urlencoded";
+            using (var reqStream = req.GetRequestStream())
+            using (var writer = new StreamWriter(reqStream))
+            {
+                writer.Write(String.Join("&", data.Select(kvp => $"{HttpUtility.UrlEncode(kvp.Key)}={HttpUtility.UrlEncode(kvp.Value)}")));
+            }
+
+            using (var resp = req.GetResponse())
+            using (var respStream = resp.GetResponseStream())
+            using (var reader = new StreamReader(respStream))
+            {
+                var json = reader.ReadToEnd();
+                var token = JsonConvert.DeserializeObject<Token>(json);
+
+                if (!String.IsNullOrEmpty(token.refresh_token))
+                    _connection.RefreshToken = token.refresh_token;
+
+                return token;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Decrypt client secret before using it for S2S auth to avoid error `AADSTS7000215: Invalid client secret is provided`
Use full file path for OAuth cache to avoid error `ERROR REQUESTING Token FROM THE Authentication context - Error: Path cannot be the empty string or all whitespace` (may be related to https://github.com/MscrmTools/MscrmTools.Xrm.Connection/issues/101)
Re-implemented refresh token auth following update to latest ADAL in https://github.com/MscrmTools/MscrmTools.Xrm.Connection/pull/99