### PR TITLE
Workaround for XrmToolbox crashing by reading empty connection  file.

### DIFF
--- a/McTools.Xrm.Connection/CrmConnections.cs
+++ b/McTools.Xrm.Connection/CrmConnections.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading;
 
 namespace McTools.Xrm.Connection
 {
@@ -70,6 +71,16 @@ namespace McTools.Xrm.Connection
                 return crmConnections;
             }
 
+            using (var fStream = OpenStream(filePath))
+            {
+                if (fStream.Length > 0)
+                {
+                    return (CrmConnections)XmlSerializerHelper.Deserialize(fStream, typeof(CrmConnections), typeof(ConnectionDetail));
+                }
+            }
+
+            Thread.Sleep(1000);
+            // try again
             using (var fStream = OpenStream(filePath))
             {
                 return (CrmConnections)XmlSerializerHelper.Deserialize(fStream, typeof(CrmConnections), typeof(ConnectionDetail));


### PR DESCRIPTION
https://github.com/MscrmTools/XrmToolBox/issues/929
probably also:
https://github.com/MscrmTools/MscrmTools.Xrm.Connection/issues/18