### PR TITLE
Fixed loading connections from URL

### DIFF
--- a/McTools.Xrm.Connection/CrmConnections.cs
+++ b/McTools.Xrm.Connection/CrmConnections.cs
@@ -73,7 +73,7 @@ namespace McTools.Xrm.Connection
 
             using (var fStream = OpenStream(filePath))
             {
-                if (fStream.Length > 0)
+                if (!fStream.CanSeek || fStream.Length > 0)
                 {
                     return (CrmConnections)XmlSerializerHelper.Deserialize(fStream, typeof(CrmConnections), typeof(ConnectionDetail));
                 }


### PR DESCRIPTION
Follow-up to #85 

The ability to load a connection list from a URL was broken in #126 as you cannot access the `.Length` property of a non-seekable stream such as that returned from an HTTP request.

This change bypasses the check for empty files where the stream is not seekable in order to restore the ability to load connection lists from a URL.