### PR TITLE
Added persistent metadata cache

### DIFF
--- a/McTools.Xrm.Connection.TestWinForm/Form1.Designer.cs
+++ b/McTools.Xrm.Connection.TestWinForm/Form1.Designer.cs
@@ -40,10 +40,14 @@
             this.tsbRequestPassword = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbImpersonate = new System.Windows.Forms.ToolStripButton();
+            this.tsbClearImpersonate = new System.Windows.Forms.ToolStripButton();
             this.panel1 = new System.Windows.Forms.Panel();
             this.panel2 = new System.Windows.Forms.Panel();
             this.lbLogs = new System.Windows.Forms.ListBox();
-            this.tsbClearImpersonate = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.tssbMetadata = new System.Windows.Forms.ToolStripSplitButton();
+            this.updateCacheToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.flushCacheToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStrip1.SuspendLayout();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
@@ -52,10 +56,10 @@
             // btnWhoAmI
             // 
             this.btnWhoAmI.Dock = System.Windows.Forms.DockStyle.Top;
-            this.btnWhoAmI.Location = new System.Drawing.Point(10, 10);
-            this.btnWhoAmI.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btnWhoAmI.Location = new System.Drawing.Point(5, 5);
+            this.btnWhoAmI.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btnWhoAmI.Name = "btnWhoAmI";
-            this.btnWhoAmI.Size = new System.Drawing.Size(1353, 44);
+            this.btnWhoAmI.Size = new System.Drawing.Size(875, 23);
             this.btnWhoAmI.TabIndex = 0;
             this.btnWhoAmI.Text = "Who am I?";
             this.btnWhoAmI.UseVisualStyleBackColor = true;
@@ -73,11 +77,13 @@
             this.tsbRequestPassword,
             this.toolStripSeparator4,
             this.tsbImpersonate,
-            this.tsbClearImpersonate});
+            this.tsbClearImpersonate,
+            this.toolStripSeparator5,
+            this.tssbMetadata});
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
             this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Padding = new System.Windows.Forms.Padding(0, 0, 3, 0);
-            this.toolStrip1.Size = new System.Drawing.Size(1373, 42);
+            this.toolStrip1.Padding = new System.Windows.Forms.Padding(0, 0, 2, 0);
+            this.toolStrip1.Size = new System.Drawing.Size(885, 25);
             this.toolStrip1.TabIndex = 1;
             this.toolStrip1.Text = "tsMain";
             // 
@@ -86,14 +92,14 @@
             this.tsbManageConnections.Image = ((System.Drawing.Image)(resources.GetObject("tsbManageConnections.Image")));
             this.tsbManageConnections.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbManageConnections.Name = "tsbManageConnections";
-            this.tsbManageConnections.Size = new System.Drawing.Size(274, 36);
+            this.tsbManageConnections.Size = new System.Drawing.Size(138, 22);
             this.tsbManageConnections.Text = "Manage connections";
             this.tsbManageConnections.Click += new System.EventHandler(this.tsbManageConnections_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 42);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
             // 
             // tsbMergeConnectionsFiles
             // 
@@ -101,14 +107,14 @@
             this.tsbMergeConnectionsFiles.Image = ((System.Drawing.Image)(resources.GetObject("tsbMergeConnectionsFiles.Image")));
             this.tsbMergeConnectionsFiles.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbMergeConnectionsFiles.Name = "tsbMergeConnectionsFiles";
-            this.tsbMergeConnectionsFiles.Size = new System.Drawing.Size(307, 36);
+            this.tsbMergeConnectionsFiles.Size = new System.Drawing.Size(153, 22);
             this.tsbMergeConnectionsFiles.Text = "Merge connections files";
             this.tsbMergeConnectionsFiles.Click += new System.EventHandler(this.tsbMergeConnectionsFiles_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 42);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
             // 
             // tsbClearLogs
             // 
@@ -116,14 +122,14 @@
             this.tsbClearLogs.Image = ((System.Drawing.Image)(resources.GetObject("tsbClearLogs.Image")));
             this.tsbClearLogs.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbClearLogs.Name = "tsbClearLogs";
-            this.tsbClearLogs.Size = new System.Drawing.Size(124, 36);
+            this.tsbClearLogs.Size = new System.Drawing.Size(63, 22);
             this.tsbClearLogs.Text = "Clear logs";
             this.tsbClearLogs.Click += new System.EventHandler(this.tsbClearLogs_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 42);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
             // 
             // tsbRequestPassword
             // 
@@ -131,14 +137,14 @@
             this.tsbRequestPassword.Image = ((System.Drawing.Image)(resources.GetObject("tsbRequestPassword.Image")));
             this.tsbRequestPassword.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbRequestPassword.Name = "tsbRequestPassword";
-            this.tsbRequestPassword.Size = new System.Drawing.Size(208, 36);
+            this.tsbRequestPassword.Size = new System.Drawing.Size(106, 22);
             this.tsbRequestPassword.Text = "Request Password";
             this.tsbRequestPassword.Click += new System.EventHandler(this.tsbRequestPassword_Click);
             // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 42);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
             // 
             // tsbImpersonate
             // 
@@ -146,39 +152,9 @@
             this.tsbImpersonate.Image = ((System.Drawing.Image)(resources.GetObject("tsbImpersonate.Image")));
             this.tsbImpersonate.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbImpersonate.Name = "tsbImpersonate";
-            this.tsbImpersonate.Size = new System.Drawing.Size(152, 36);
+            this.tsbImpersonate.Size = new System.Drawing.Size(77, 22);
             this.tsbImpersonate.Text = "Impersonate";
             this.tsbImpersonate.Click += new System.EventHandler(this.tsbImpersonate_Click);
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.btnWhoAmI);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel1.Location = new System.Drawing.Point(0, 42);
-            this.panel1.Name = "panel1";
-            this.panel1.Padding = new System.Windows.Forms.Padding(10);
-            this.panel1.Size = new System.Drawing.Size(1373, 66);
-            this.panel1.TabIndex = 2;
-            // 
-            // panel2
-            // 
-            this.panel2.Controls.Add(this.lbLogs);
-            this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel2.Location = new System.Drawing.Point(0, 108);
-            this.panel2.Name = "panel2";
-            this.panel2.Padding = new System.Windows.Forms.Padding(10);
-            this.panel2.Size = new System.Drawing.Size(1373, 414);
-            this.panel2.TabIndex = 3;
-            // 
-            // lbLogs
-            // 
-            this.lbLogs.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lbLogs.FormattingEnabled = true;
-            this.lbLogs.ItemHeight = 25;
-            this.lbLogs.Location = new System.Drawing.Point(10, 10);
-            this.lbLogs.Name = "lbLogs";
-            this.lbLogs.Size = new System.Drawing.Size(1353, 394);
-            this.lbLogs.TabIndex = 0;
             // 
             // tsbClearImpersonate
             // 
@@ -186,19 +162,83 @@
             this.tsbClearImpersonate.Image = ((System.Drawing.Image)(resources.GetObject("tsbClearImpersonate.Image")));
             this.tsbClearImpersonate.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbClearImpersonate.Name = "tsbClearImpersonate";
-            this.tsbClearImpersonate.Size = new System.Drawing.Size(234, 36);
+            this.tsbClearImpersonate.Size = new System.Drawing.Size(118, 22);
             this.tsbClearImpersonate.Text = "Clear Impersonation";
             this.tsbClearImpersonate.Click += new System.EventHandler(this.tsbClearImpersonate_Click);
             // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.btnWhoAmI);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel1.Location = new System.Drawing.Point(0, 25);
+            this.panel1.Margin = new System.Windows.Forms.Padding(2);
+            this.panel1.Name = "panel1";
+            this.panel1.Padding = new System.Windows.Forms.Padding(5);
+            this.panel1.Size = new System.Drawing.Size(885, 32);
+            this.panel1.TabIndex = 2;
+            // 
+            // panel2
+            // 
+            this.panel2.Controls.Add(this.lbLogs);
+            this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel2.Location = new System.Drawing.Point(0, 57);
+            this.panel2.Margin = new System.Windows.Forms.Padding(2);
+            this.panel2.Name = "panel2";
+            this.panel2.Padding = new System.Windows.Forms.Padding(5);
+            this.panel2.Size = new System.Drawing.Size(885, 214);
+            this.panel2.TabIndex = 3;
+            // 
+            // lbLogs
+            // 
+            this.lbLogs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lbLogs.FormattingEnabled = true;
+            this.lbLogs.Location = new System.Drawing.Point(5, 5);
+            this.lbLogs.Margin = new System.Windows.Forms.Padding(2);
+            this.lbLogs.Name = "lbLogs";
+            this.lbLogs.Size = new System.Drawing.Size(875, 204);
+            this.lbLogs.TabIndex = 0;
+            // 
+            // toolStripSeparator5
+            // 
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
+            // 
+            // tssbMetadata
+            // 
+            this.tssbMetadata.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tssbMetadata.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.updateCacheToolStripMenuItem,
+            this.flushCacheToolStripMenuItem});
+            this.tssbMetadata.Image = ((System.Drawing.Image)(resources.GetObject("tssbMetadata.Image")));
+            this.tssbMetadata.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tssbMetadata.Name = "tssbMetadata";
+            this.tssbMetadata.Size = new System.Drawing.Size(105, 22);
+            this.tssbMetadata.Text = "Show Metadata";
+            this.tssbMetadata.ButtonClick += new System.EventHandler(this.tssbMetadata_ButtonClick);
+            // 
+            // updateCacheToolStripMenuItem
+            // 
+            this.updateCacheToolStripMenuItem.Name = "updateCacheToolStripMenuItem";
+            this.updateCacheToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.updateCacheToolStripMenuItem.Text = "Update Cache";
+            this.updateCacheToolStripMenuItem.Click += new System.EventHandler(this.updateCacheToolStripMenuItem_Click);
+            // 
+            // flushCacheToolStripMenuItem
+            // 
+            this.flushCacheToolStripMenuItem.Name = "flushCacheToolStripMenuItem";
+            this.flushCacheToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.flushCacheToolStripMenuItem.Text = "Flush Cache";
+            this.flushCacheToolStripMenuItem.Click += new System.EventHandler(this.flushCacheToolStripMenuItem_Click);
+            // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1373, 522);
+            this.ClientSize = new System.Drawing.Size(885, 271);
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.Name = "Form1";
             this.Text = "Who Am I Sample";
             this.toolStrip1.ResumeLayout(false);
@@ -227,6 +267,10 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripButton tsbImpersonate;
         private System.Windows.Forms.ToolStripButton tsbClearImpersonate;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+        private System.Windows.Forms.ToolStripSplitButton tssbMetadata;
+        private System.Windows.Forms.ToolStripMenuItem updateCacheToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem flushCacheToolStripMenuItem;
     }
 }
 

--- a/McTools.Xrm.Connection.TestWinForm/Form1.cs
+++ b/McTools.Xrm.Connection.TestWinForm/Form1.cs
@@ -234,5 +234,41 @@ namespace McTools.Xrm.Connection.TestWinForm
                 MessageBox.Show($"Cannot get password for the following reason: {reason}");
             }
         }
+
+        private void tssbMetadata_ButtonClick(object sender, EventArgs e)
+        {
+            if (currentDetail == null)
+            {
+                MessageBox.Show("Please connect first");
+                return;
+            }
+
+            foreach (var entity in currentDetail.MetadataCache.OrderBy(entity => entity.LogicalName))
+            {
+                lbLogs.Items.Add($"{entity.LogicalName}: {entity.DisplayName.UserLocalizedLabel?.Label}");
+            }
+        }
+
+        private void updateCacheToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (currentDetail == null)
+            {
+                MessageBox.Show("Please connect first");
+                return;
+            }
+
+            currentDetail.UpdateMetadataCache(false);
+        }
+
+        private void flushCacheToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (currentDetail == null)
+            {
+                MessageBox.Show("Please connect first");
+                return;
+            }
+
+            currentDetail.UpdateMetadataCache(true);
+        }
     }
 }

--- a/McTools.Xrm.Connection.TestWinForm/Form1.resx
+++ b/McTools.Xrm.Connection.TestWinForm/Form1.resx
@@ -124,7 +124,7 @@
   <data name="tsbManageConnections.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAMbSURBVDhPfZLrb5NlGMbfP8APfMRI+CBxGBFjPASNCdNA
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAMbSURBVDhPfZLrb5NlGMbfP8APfMRI+CBxGBFjPASNCdNA
         YqJL+OIHD4khTpERJSgHx0A3li1kK6OtMrZuE9ZtBTLat61lRXBI177t0rVbt8JYD7DiPIwo2tJ2XU/z
         59MuOiHRK/nlfvLkvq77/nBLJTV2DhobO4wcKdFppqHLTn33MLXdij74VYXer92AT/MEPrWgVP9hA1J9
         +6Cx1+7hoi+MfSzM0Pgc/sEaprVrCWrXETv/OoVwK/mb7eQjGsFx8uFj5EIqQQvSIe0ZUrki8VSWP1J5
@@ -144,7 +144,7 @@
   <data name="tsbMergeConnectionsFiles.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -159,7 +159,7 @@
   <data name="tsbClearLogs.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -174,7 +174,7 @@
   <data name="tsbRequestPassword.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -189,7 +189,7 @@
   <data name="tsbImpersonate.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -204,7 +204,22 @@
   <data name="tsbClearImpersonate.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="tssbMetadata.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc

--- a/McTools.Xrm.Connection.WinForms/McTools.Xrm.Connection.WinForms.csproj
+++ b/McTools.Xrm.Connection.WinForms/McTools.Xrm.Connection.WinForms.csproj
@@ -58,7 +58,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>McTools.Xrm.Connection.WinForms.pfx</AssemblyOriginatorKeyFile>

--- a/McTools.Xrm.Connection/ConnectionManager.cs
+++ b/McTools.Xrm.Connection/ConnectionManager.cs
@@ -487,6 +487,8 @@ namespace McTools.Xrm.Connection
                     detail.CopyClientSecretTo(currentConnection);
                 }
 
+                UpdateMetadataCache(detail);
+
                 detail.LastUsedOn = DateTime.Now;
 
                 SaveConnectionsFile();
@@ -502,6 +504,13 @@ namespace McTools.Xrm.Connection
             {
                 return error;
             }
+        }
+
+        private void UpdateMetadataCache(ConnectionDetail detail)
+        {
+            SendStepChange("Updating Metadata Cache...");
+
+            detail.UpdateMetadataCache(false);
         }
 
         /// <summary>
@@ -605,6 +614,8 @@ namespace McTools.Xrm.Connection
             var parameters = new List<object> { detail, connectionParameter, 1 };
 
             if (crmSvc == null) return;
+
+            UpdateMetadataCache(detail);
 
             if (crmSvc.IsReady)
             {

--- a/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
+++ b/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
@@ -73,7 +73,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>McTools.Xrm.Connection.pfx</AssemblyOriginatorKeyFile>
@@ -165,6 +165,7 @@
     <Compile Include="Forms\PasswordRequestDialog.Designer.cs">
       <DependentUpon>PasswordRequestDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="MetadataCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AutoRefreshSecurityToken.cs" />
     <Compile Include="Utils\ManagedTokenDiscoveryServiceProxy.cs" />
@@ -202,7 +203,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_UpdateAssemblyVersion="False" BuildVersion_UpdateFileVersion="False" BuildVersion_BuildVersioningStyle="None.None.DeltaBaseDate.Increment" BuildVersion_StartDate="2012/1/1" />
+      <UserProperties BuildVersion_StartDate="2012/1/1" BuildVersion_BuildVersioningStyle="None.None.DeltaBaseDate.Increment" BuildVersion_UpdateFileVersion="False" BuildVersion_UpdateAssemblyVersion="False" BuildVersion_ConfigurationName="Release" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>

--- a/McTools.Xrm.Connection/MetadataCache.cs
+++ b/McTools.Xrm.Connection/MetadataCache.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xrm.Sdk.Metadata;
+
+namespace McTools.Xrm.Connection
+{
+    [DataContract(Name = "MetadataCache", Namespace = "https://www.xrmtoolbox.com")]
+    public class MetadataCache
+    {
+        [DataMember]
+        public int MetadataQueryVersion { get; set; }
+
+        [DataMember]
+        public string ClientVersionStamp { get; set; }
+
+        [DataMember]
+        public EntityMetadata[] EntityMetadata { get; set; } 
+    }
+}


### PR DESCRIPTION
Proof of concept for persistent metadata cache - addresses #135 

The cache is:

* Shared between tools
* Stored in `Metadata` folder next to connection list folder
* Stored in a separate .xml.gz file per connection
* Updated automatically on each new connection
* Accessed by tools via `ConnectionDetail.MetadataCache`
* Updated manually via `ConnectionDetail.UpdateMetadataCache(bool flush)`
* Complete - stores all properties of Entity, Attribute and Relationship metadata

In my tests the initial metadata retrieval takes ~6-10 seconds. Subsequent connections take around 2 seconds to load the cached file, then <1 second to retrieve and apply any updates. The stored files for my environments have been 5-9MB each.