### PR TITLE
Metadata cache

### DIFF
--- a/McTools.Xrm.Connection/ConnectionManager.cs
+++ b/McTools.Xrm.Connection/ConnectionManager.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Net.Security;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using EndpointCollection = Microsoft.Xrm.Sdk.Organization.EndpointCollection;
 
 namespace McTools.Xrm.Connection
@@ -512,7 +513,14 @@ namespace McTools.Xrm.Connection
         {
             SendStepChange("Updating Metadata Cache...");
 
-            detail.UpdateMetadataCache(false);
+            var task = detail.UpdateMetadataCache(false);
+            task.ContinueWith(t =>
+            {
+                if (t.Status == TaskStatus.RanToCompletion)
+                    SendStepChange("Metadata Cache Updated");
+                else
+                    SendStepChange("Metadata Cache Update Failed: " + t.Exception.InnerException.Message);
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Previous version of the metadata cache would not correctly remove a deleted attribute from the cached entity metadata unless there was also some other change to the same entity. This change makes it scan all the cached metadata to find the deleted items that need to be removed.

There was also no indication when the metadata update process had completed - this now updates the status message.