### PR TITLE
Metadata cache

### DIFF
--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -1066,16 +1066,23 @@ namespace McTools.Xrm.Connection
 
                 if (metadataCache == null && File.Exists(metadataCachePath) && !flush)
                 {
-                    using (var stream = File.OpenRead(metadataCachePath))
-                    using (var gz = new GZipStream(stream, CompressionMode.Decompress))
+                    try
                     {
-                        metadataCache = (MetadataCache)metadataSerializer.ReadObject(gz);
+                        using (var stream = File.OpenRead(metadataCachePath))
+                        using (var gz = new GZipStream(stream, CompressionMode.Decompress))
+                        {
+                            metadataCache = (MetadataCache)metadataSerializer.ReadObject(gz);
+                        }
+                    }
+                    catch
+                    {
+                        // If the cache file isn't readable for any reason, throw it away and download a new copy
                     }
                 }
 
                 // Get all the metadata that's changed since the last connection
                 // If this query changes, increment the version number to ensure any previously cached versions are flushed
-                const int queryVersion = 1;
+                const int queryVersion = 2;
 
                 var metadataQuery = new RetrieveMetadataChangesRequest
                 {

--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -1210,11 +1210,13 @@ namespace McTools.Xrm.Connection
 
                 if (!typeof(MetadataBase).IsAssignableFrom(type) && !typeof(Label).IsAssignableFrom(type))
                 {
-                    prop.SetValue(existingItem, newValue);
+                    if (newItem.HasChanged != false)
+                        prop.SetValue(existingItem, newValue);
                 }
                 else if (typeof(Label).IsAssignableFrom(type))
                 {
-                    CopyChanges((Label)prop.GetValue(existingItem), (Label)newValue, deletedIds);
+                    if (newItem.HasChanged != false)
+                        CopyChanges((Label)prop.GetValue(existingItem), (Label)newValue, deletedIds);
                 }
                 else if (newValue != null)
                 {
@@ -1329,76 +1331,6 @@ namespace McTools.Xrm.Connection
 
             if (label.UserLocalizedLabel != null)
                 RemoveDeletedItems(label.UserLocalizedLabel, deletedIds);
-        }
-
-        private void CopyChanges(MetadataBase existingItem, MetadataBase newItem, List<Guid> deletedIds)
-        {
-            foreach (var prop in existingItem.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (!Attribute.IsDefined(prop, typeof(DataMemberAttribute)))
-                    continue;
-
-                var newValue = prop.GetValue(newItem);
-                var existingValue = prop.GetValue(existingItem) as MetadataBase;
-                var type = prop.PropertyType;
-
-                if (type.IsArray)
-                    type = type.GetElementType();
-
-                if (!typeof(MetadataBase).IsAssignableFrom(type) && !typeof(Label).IsAssignableFrom(type))
-                {
-                    if (newItem.HasChanged != false)
-                        prop.SetValue(existingItem, newValue);
-                }
-                else if (typeof(Label).IsAssignableFrom(type))
-                {
-                    if (newItem.HasChanged != false)
-                        CopyChanges((Label)prop.GetValue(existingItem), (Label)newValue, deletedIds);
-                }
-                else if (newValue != null)
-                {
-                    if (prop.PropertyType.IsArray)
-                    {
-                        CopyChanges(existingItem, prop, (MetadataBase[])newValue, deletedIds);
-                    }
-                    else
-                    {
-                        if (existingValue.MetadataId == ((MetadataBase)newValue).MetadataId)
-                            CopyChanges(existingValue, (MetadataBase)newValue, deletedIds);
-                        else
-                            prop.SetValue(existingItem, newValue);
-                    }
-                }
-                else if (existingValue != null && deletedIds.Contains(existingValue.MetadataId.Value))
-                {
-                    prop.SetValue(existingItem, null);
-                }
-            }
-        }
-
-        private void CopyChanges(Label existingLabel, Label newLabel, List<Guid> deletedIds)
-        {
-            if (newLabel == null)
-                return;
-
-            foreach (var localizedLabel in newLabel.LocalizedLabels)
-            {
-                var existingLocalizedLabel = existingLabel.LocalizedLabels.SingleOrDefault(ll => ll.MetadataId == localizedLabel.MetadataId);
-
-                if (existingLocalizedLabel == null)
-                    existingLabel.LocalizedLabels.Add(localizedLabel);
-                else
-                    CopyChanges(existingLocalizedLabel, localizedLabel, deletedIds);
-            }
-
-            for (var i = existingLabel.LocalizedLabels.Count - 1; i >= 0; i--)
-            {
-                if (deletedIds.Contains(existingLabel.LocalizedLabels[i].MetadataId.Value))
-                    existingLabel.LocalizedLabels.RemoveAt(i);
-            }
-
-            if (newLabel.UserLocalizedLabel != null)
-                CopyChanges(existingLabel.UserLocalizedLabel, newLabel.UserLocalizedLabel, deletedIds);
         }
 
         #endregion Metadata Cache methods

--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -1279,11 +1279,13 @@ namespace McTools.Xrm.Connection
 
                 if (!typeof(MetadataBase).IsAssignableFrom(type) && !typeof(Label).IsAssignableFrom(type))
                 {
-                    prop.SetValue(existingItem, newValue);
+                    if (newItem.HasChanged != false)
+                        prop.SetValue(existingItem, newValue);
                 }
                 else if (typeof(Label).IsAssignableFrom(type))
                 {
-                    CopyChanges((Label)prop.GetValue(existingItem), (Label)newValue, deletedIds);
+                    if (newItem.HasChanged != false)
+                        CopyChanges((Label)prop.GetValue(existingItem), (Label)newValue, deletedIds);
                 }
                 else if (newValue != null)
                 {


### PR DESCRIPTION
Fixes an error where properties of a cached `EntityMetadata` object could be set to `null` if there were changes only to one of the related attributes.

Also ensures that an invalid or inaccessible cache file does not prevent the cache from being refreshed.