### PR TITLE
Fixed NullReferenceException when accessing MetadataCache

### DIFF
--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -178,7 +178,7 @@ namespace McTools.Xrm.Connection
         /// This cache is updated at the start of each connection, or by calling <see cref="UpdateMetadataCache(bool)"/>
         /// </remarks>
         [XmlIgnore]
-        public EntityMetadata[] MetadataCache => _metadataCache.EntityMetadata;
+        public EntityMetadata[] MetadataCache => _metadataCache?.EntityMetadata;
 
         /// <summary>
         /// Returns a task that provides access to the <see cref="MetadataCache"/> once it has finished loading


### PR DESCRIPTION
Fixed NullReferenceException when accessing MetadataCache before it has finished loading