### PR TITLE
Reset metadata cache after any changes

### DIFF
--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -1307,7 +1307,12 @@ namespace McTools.Xrm.Connection
             }
 
             if (newLabel.UserLocalizedLabel != null)
-                CopyChanges(existingLabel.UserLocalizedLabel, newLabel.UserLocalizedLabel, deletedIds);
+            {
+                if (existingLabel.UserLocalizedLabel == null)
+                    existingLabel.UserLocalizedLabel = newLabel.UserLocalizedLabel;
+                else
+                    CopyChanges(existingLabel.UserLocalizedLabel, newLabel.UserLocalizedLabel, deletedIds);
+            }
         }
 
         private void RemoveDeletedItems(object source, PropertyInfo sourceProperty, List<Guid> deletedIds)


### PR DESCRIPTION
When the current version receives a change to the metadata, it attempts to apply that change to the cached version by matching the metadata IDs. However, I have seen instances where the IDs can change (e.g. when an environment is overwritten with a copy of another environment), so it appears the only safe way to update the cache is to get a whole fresh copy when any changes are detected.

This also makes the caching code much simpler and less error prone, although it leads to a longer delay on the first connection after a metadata change.