### PR TITLE
Allow using GetCrmServiceClient(true) for SDK Login Control connections

### DIFF
--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -370,7 +370,18 @@ namespace McTools.Xrm.Connection
             }
             CrmServiceClient.MaxConnectionTimeout = Timeout;
 
-            if (Certificate != null)
+            if (IsFromSdkLoginCtrl)
+            {
+                if (crmSvc != null)
+                {
+                    SetImpersonationCapability();
+
+                    return crmSvc;
+                }
+
+                throw new ApplicationException("Connections using the SDK Login Control cannot be created automatically");
+            }
+            else if (Certificate != null)
             {
                 var cs = HandleConnectionString($"AuthType=Certificate;url={OriginalUrl};thumbprint={Certificate.Thumbprint};ClientId={AzureAdAppId};");
                 crmSvc = new CrmServiceClient(cs);


### PR DESCRIPTION
Currently, if you have a connection that uses the SDK Login Control and call the `ConnectionDetail.GetCrmServiceClient(forceNewService: true)` method, it will follow the path of trying to use the standard on-prem AD authentication. This will likely fail because the credentials are not available or the port number is incorrect if the service is using HTTPS.

As far as I know, connecting using the SDK Login Control requires a UI and therefore there doesn't seem to be a nice way of making this work in the same way as other authentication types. In this PR I'm proposing to simply ignore the `forceNewService: true` parameter in these cases so that it doesn't fail in unexpected ways, but I'm open to other suggestions.