### PR TITLE
Allow loading connection list from external assembly

### DIFF
--- a/McTools.Xrm.Connection.TestWinForm/CrmConnectionProvider.cs
+++ b/McTools.Xrm.Connection.TestWinForm/CrmConnectionProvider.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Xrm.Tooling.Connector;
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace McTools.Xrm.Connection.TestWinForm
+{
+    public class CrmConnectionProvider : ICrmConnectionsProvider
+    {
+        class PromptOnConnectConnectionDetail : ConnectionDetail
+        {
+            public override CrmServiceClient GetCrmServiceClient(bool forceNewService = false)
+            {
+                MessageBox.Show("Connecting to " + ConnectionName);
+
+                return base.GetCrmServiceClient(forceNewService);
+            }
+        }
+
+        public CrmConnections LoadCrmConnections()
+        {
+            // Provider can load the connection list dynamically here, from a database, API, ...
+            return new CrmConnections("Dynamic Demo")
+            {
+                IsReadOnly = true,
+                Connections = new List<ConnectionDetail>
+                {
+                    new PromptOnConnectConnectionDetail
+                    {
+                        ConnectionId = Guid.NewGuid(),
+                        OriginalUrl = "https://contoso.crm.dynamics.com",
+                        WebApplicationUrl = "https://contoso.crm.dynamics.com",
+                        ConnectionName = "Demo Connection",
+                        NewAuthType = AuthenticationType.OAuth,
+                        UseMfa = true,
+                        AzureAdAppId = new Guid("51f81489-12ee-4a9e-aaae-a2591f45987d"),
+                        ReplyUrl = "app://58145B91-0C36-4500-8554-080854F2AC97",
+                        UserName = "example@contoso.com"
+                    }
+                }
+            };
+        }
+    }
+}

--- a/McTools.Xrm.Connection.TestWinForm/McTools.Xrm.Connection.TestWinForm.csproj
+++ b/McTools.Xrm.Connection.TestWinForm/McTools.Xrm.Connection.TestWinForm.csproj
@@ -200,6 +200,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CrmConnectionProvider.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/McTools.Xrm.Connection.WinForms/ConnectionSelector.cs
+++ b/McTools.Xrm.Connection.WinForms/ConnectionSelector.cs
@@ -729,6 +729,7 @@ namespace McTools.Xrm.Connection.WinForms
                         Text = dialog.TextSelected
                     };
 
+                    connection.UpdateAfterEdit(connection);
                     ConnectionManager.ConfigurationFile = ((ConnectionFile)lvConnectionFiles.SelectedItems[0].Tag).Path;
                     ConnectionManager.Instance.SaveConnectionsFile();
                     lvConnections.Invalidate();

--- a/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -545,7 +545,7 @@ namespace McTools.Xrm.Connection
             clientSecret = null;
         }
 
-        public CrmServiceClient GetCrmServiceClient(bool forceNewService = false)
+        public virtual CrmServiceClient GetCrmServiceClient(bool forceNewService = false)
         {
             if (forceNewService == false && crmSvc != null)
             {
@@ -665,7 +665,7 @@ namespace McTools.Xrm.Connection
             return crmSvc;
         }
 
-        public void SetClientSecret(string secret, bool isEncrypted = false)
+        public virtual void SetClientSecret(string secret, bool isEncrypted = false)
         {
             if (!string.IsNullOrEmpty(secret))
             {
@@ -685,7 +685,7 @@ namespace McTools.Xrm.Connection
             }
         }
 
-        public void SetConnectionString(string connectionString)
+        public virtual void SetConnectionString(string connectionString)
         {
             var csb = new DbConnectionStringBuilder { ConnectionString = connectionString };
 
@@ -716,7 +716,7 @@ namespace McTools.Xrm.Connection
             ConnectionString = csb.ToString();
         }
 
-        public void SetPassword(string password, bool isEncrypted = false)
+        public virtual void SetPassword(string password, bool isEncrypted = false)
         {
             if (!string.IsNullOrEmpty(password))
             {
@@ -755,7 +755,7 @@ namespace McTools.Xrm.Connection
             return ConnectionName;
         }
 
-        public bool TryRequestClientSecret(Control parent, string secretUsageDescription, out string secret, out SensitiveDataNotFoundReason notFoundReason)
+        public virtual bool TryRequestClientSecret(Control parent, string secretUsageDescription, out string secret, out SensitiveDataNotFoundReason notFoundReason)
         {
             using (var prd = new PasswordRequestDialog(secretUsageDescription, this, "client secret"))
             {
@@ -785,7 +785,7 @@ namespace McTools.Xrm.Connection
             }
         }
 
-        public bool TryRequestPassword(Control parent, string passwordUsageDescription, out string password, out SensitiveDataNotFoundReason notFoundReason)
+        public virtual bool TryRequestPassword(Control parent, string passwordUsageDescription, out string password, out SensitiveDataNotFoundReason notFoundReason)
         {
             using (var prd = new PasswordRequestDialog(passwordUsageDescription, this, "password"))
             {
@@ -815,7 +815,7 @@ namespace McTools.Xrm.Connection
             }
         }
 
-        public void UpdateAfterEdit(ConnectionDetail editedConnection)
+        public virtual void UpdateAfterEdit(ConnectionDetail editedConnection)
         {
             ConnectionName = editedConnection.ConnectionName;
             ConnectionString = editedConnection.ConnectionString;
@@ -1086,7 +1086,7 @@ namespace McTools.Xrm.Connection
 
         #endregion Méthodes
 
-        public object Clone()
+        public virtual object Clone()
         {
             var cd = new ConnectionDetail
             {

--- a/McTools.Xrm.Connection/ICrmConnectionsProvider.cs
+++ b/McTools.Xrm.Connection/ICrmConnectionsProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace McTools.Xrm.Connection
+{
+    public interface ICrmConnectionsProvider
+    {
+        CrmConnections LoadCrmConnections();
+    }
+}

--- a/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
+++ b/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Forms\PasswordRequestDialog.Designer.cs">
       <DependentUpon>PasswordRequestDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="ICrmConnectionsProvider.cs" />
     <Compile Include="MetadataCache.cs" />
     <Compile Include="MetadataCacheContractResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
We currently have the option to load a connection list from a URL, which lets a web server dynamically generate the XML list of connections. However, this has a limitation of only allowing Windows authentication for that site.

This PR allows adding a .NET assembly as a connection list as well as a simple XML file. If an assembly is selected it will find a class in that assembly that implements a new `ICrmConnectionsProvider` interface, create an instance of that provider type and call a method on it to retrieve a list of collections. This allows organisations to implement completely custom logic to provide a list of connections. For example, a central database of connections for all their customers but different consultants have access to only the instances they require.

It also makes various methods on the `ConnectionDetail` class virtual. This allows the provider to return a derived class that adds extra functionality such as audit logging each time a connection is used.

I've included an example implementation within the TestWinForm app, so you can add the McTools.Xmr.Connection.TestWinForm.exe assembly as a connection list file and see an example connection.