### PR TITLE
Added options for Azure Key Vault

### DIFF
--- a/McTools.Xrm.Connection.WinForms/ConnectionSelector.designer.cs
+++ b/McTools.Xrm.Connection.WinForms/ConnectionSelector.designer.cs
@@ -69,10 +69,9 @@
             // bValidate
             // 
             this.bValidate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.bValidate.Location = new System.Drawing.Point(916, 5);
-            this.bValidate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.bValidate.Location = new System.Drawing.Point(611, 3);
             this.bValidate.Name = "bValidate";
-            this.bValidate.Size = new System.Drawing.Size(112, 35);
+            this.bValidate.Size = new System.Drawing.Size(75, 23);
             this.bValidate.TabIndex = 3;
             this.bValidate.Text = "OK";
             this.bValidate.UseVisualStyleBackColor = true;
@@ -82,10 +81,9 @@
             // 
             this.bCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.bCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.bCancel.Location = new System.Drawing.Point(1038, 5);
-            this.bCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.bCancel.Location = new System.Drawing.Point(692, 3);
             this.bCancel.Name = "bCancel";
-            this.bCancel.Size = new System.Drawing.Size(112, 35);
+            this.bCancel.Size = new System.Drawing.Size(75, 23);
             this.bCancel.TabIndex = 4;
             this.bCancel.Text = "Cancel";
             this.bCancel.UseVisualStyleBackColor = true;
@@ -105,10 +103,9 @@
             this.lvConnections.GridLines = true;
             this.lvConnections.HideSelection = false;
             this.lvConnections.LabelEdit = true;
-            this.lvConnections.Location = new System.Drawing.Point(7, 6);
-            this.lvConnections.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.lvConnections.Location = new System.Drawing.Point(5, 4);
             this.lvConnections.Name = "lvConnections";
-            this.lvConnections.Size = new System.Drawing.Size(1380, 630);
+            this.lvConnections.Size = new System.Drawing.Size(765, 345);
             this.lvConnections.TabIndex = 2;
             this.lvConnections.UseCompatibleStateImageBehavior = false;
             this.lvConnections.View = System.Windows.Forms.View.Details;
@@ -174,7 +171,7 @@
             this.tstSearch});
             this.menu.Location = new System.Drawing.Point(0, 0);
             this.menu.Name = "menu";
-            this.menu.Size = new System.Drawing.Size(1394, 46);
+            this.menu.Size = new System.Drawing.Size(775, 25);
             this.menu.TabIndex = 1;
             this.menu.Text = "tsMain";
             // 
@@ -183,7 +180,7 @@
             this.tsbNewConnection.Image = ((System.Drawing.Image)(resources.GetObject("tsbNewConnection.Image")));
             this.tsbNewConnection.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbNewConnection.Name = "tsbNewConnection";
-            this.tsbNewConnection.Size = new System.Drawing.Size(159, 41);
+            this.tsbNewConnection.Size = new System.Drawing.Size(114, 22);
             this.tsbNewConnection.Text = "New connection";
             this.tsbNewConnection.Click += new System.EventHandler(this.tsbNewConnection_Click);
             // 
@@ -193,7 +190,7 @@
             this.tsbUpdateConnection.Image = ((System.Drawing.Image)(resources.GetObject("tsbUpdateConnection.Image")));
             this.tsbUpdateConnection.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbUpdateConnection.Name = "tsbUpdateConnection";
-            this.tsbUpdateConnection.Size = new System.Drawing.Size(34, 41);
+            this.tsbUpdateConnection.Size = new System.Drawing.Size(23, 22);
             this.tsbUpdateConnection.Text = "Update connection";
             this.tsbUpdateConnection.Click += new System.EventHandler(this.tsbUpdateConnection_Click);
             // 
@@ -203,7 +200,7 @@
             this.tsbCloneConnection.Image = ((System.Drawing.Image)(resources.GetObject("tsbCloneConnection.Image")));
             this.tsbCloneConnection.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbCloneConnection.Name = "tsbCloneConnection";
-            this.tsbCloneConnection.Size = new System.Drawing.Size(34, 41);
+            this.tsbCloneConnection.Size = new System.Drawing.Size(23, 22);
             this.tsbCloneConnection.Text = "Clone connection";
             this.tsbCloneConnection.Click += new System.EventHandler(this.tsbCloneConnection_Click);
             // 
@@ -213,14 +210,14 @@
             this.tsbDeleteConnection.Image = ((System.Drawing.Image)(resources.GetObject("tsbDeleteConnection.Image")));
             this.tsbDeleteConnection.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbDeleteConnection.Name = "tsbDeleteConnection";
-            this.tsbDeleteConnection.Size = new System.Drawing.Size(34, 41);
+            this.tsbDeleteConnection.Size = new System.Drawing.Size(23, 22);
             this.tsbDeleteConnection.Text = "Delete connection";
             this.tsbDeleteConnection.Click += new System.EventHandler(this.tsbDeleteConnection_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 46);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
             // 
             // tsbUpdatePassword
             // 
@@ -228,7 +225,7 @@
             this.tsbUpdatePassword.Image = ((System.Drawing.Image)(resources.GetObject("tsbUpdatePassword.Image")));
             this.tsbUpdatePassword.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbUpdatePassword.Name = "tsbUpdatePassword";
-            this.tsbUpdatePassword.Size = new System.Drawing.Size(34, 41);
+            this.tsbUpdatePassword.Size = new System.Drawing.Size(23, 22);
             this.tsbUpdatePassword.Text = "Update password";
             this.tsbUpdatePassword.ToolTipText = "Update password for selected connection(s)";
             this.tsbUpdatePassword.Click += new System.EventHandler(this.tsbUpdatePassword_Click);
@@ -236,7 +233,7 @@
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 46);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
             // 
             // tsbShowConnectionString
             // 
@@ -244,7 +241,7 @@
             this.tsbShowConnectionString.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.database_link;
             this.tsbShowConnectionString.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbShowConnectionString.Name = "tsbShowConnectionString";
-            this.tsbShowConnectionString.Size = new System.Drawing.Size(34, 41);
+            this.tsbShowConnectionString.Size = new System.Drawing.Size(23, 22);
             this.tsbShowConnectionString.Text = "Show connection string";
             this.tsbShowConnectionString.ToolTipText = "Show connection string for this connection";
             this.tsbShowConnectionString.Click += new System.EventHandler(this.tsbShowConnectionString_Click);
@@ -255,14 +252,14 @@
             this.tsbSetProfile.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.world;
             this.tsbSetProfile.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbSetProfile.Name = "tsbSetProfile";
-            this.tsbSetProfile.Size = new System.Drawing.Size(34, 41);
+            this.tsbSetProfile.Size = new System.Drawing.Size(23, 22);
             this.tsbSetProfile.Text = "Set Browser profile";
             this.tsbSetProfile.Click += new System.EventHandler(this.tsbSetProfile_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 46);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
             // 
             // tsb_UseMru
             // 
@@ -271,21 +268,20 @@
             this.tsb_UseMru.Image = ((System.Drawing.Image)(resources.GetObject("tsb_UseMru.Image")));
             this.tsb_UseMru.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsb_UseMru.Name = "tsb_UseMru";
-            this.tsb_UseMru.Size = new System.Drawing.Size(34, 41);
+            this.tsb_UseMru.Size = new System.Drawing.Size(23, 22);
             this.tsb_UseMru.Text = "Display MRU first";
             this.tsb_UseMru.ToolTipText = "Display Most Recently Used connections first";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 46);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
             // 
             // tscbbConnectionsFile
             // 
             this.tscbbConnectionsFile.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.tscbbConnectionsFile.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.tscbbConnectionsFile.Name = "tscbbConnectionsFile";
-            this.tscbbConnectionsFile.Size = new System.Drawing.Size(280, 46);
+            this.tscbbConnectionsFile.Size = new System.Drawing.Size(188, 25);
             this.tscbbConnectionsFile.SelectedIndexChanged += new System.EventHandler(this.tscbbConnectionsFile_SelectedIndexChanged);
             // 
             // tsbRemoveConnectionList
@@ -294,7 +290,7 @@
             this.tsbRemoveConnectionList.Image = ((System.Drawing.Image)(resources.GetObject("tsbRemoveConnectionList.Image")));
             this.tsbRemoveConnectionList.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbRemoveConnectionList.Name = "tsbRemoveConnectionList";
-            this.tsbRemoveConnectionList.Size = new System.Drawing.Size(34, 41);
+            this.tsbRemoveConnectionList.Size = new System.Drawing.Size(23, 22);
             this.tsbRemoveConnectionList.Text = "Remove selected connection list";
             this.tsbRemoveConnectionList.Click += new System.EventHandler(this.tsbRemoveConnectionList_Click);
             // 
@@ -304,7 +300,7 @@
             this.tsbMoveToNewFile.Image = ((System.Drawing.Image)(resources.GetObject("tsbMoveToNewFile.Image")));
             this.tsbMoveToNewFile.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbMoveToNewFile.Name = "tsbMoveToNewFile";
-            this.tsbMoveToNewFile.Size = new System.Drawing.Size(34, 41);
+            this.tsbMoveToNewFile.Size = new System.Drawing.Size(23, 22);
             this.tsbMoveToNewFile.Text = "Move selected connections to a new file";
             this.tsbMoveToNewFile.Visible = false;
             this.tsbMoveToNewFile.Click += new System.EventHandler(this.tsbMoveToNewFile_Click);
@@ -315,7 +311,7 @@
             this.tsbMoveToExistingFile.Image = ((System.Drawing.Image)(resources.GetObject("tsbMoveToExistingFile.Image")));
             this.tsbMoveToExistingFile.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbMoveToExistingFile.Name = "tsbMoveToExistingFile";
-            this.tsbMoveToExistingFile.Size = new System.Drawing.Size(34, 41);
+            this.tsbMoveToExistingFile.Size = new System.Drawing.Size(29, 22);
             this.tsbMoveToExistingFile.Text = "Move selected connections to existing file";
             this.tsbMoveToExistingFile.Visible = false;
             this.tsbMoveToExistingFile.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.tsbMoveToExistingFile_DropDownItemClicked);
@@ -326,26 +322,26 @@
             this.tsbRenameFile.Image = ((System.Drawing.Image)(resources.GetObject("tsbRenameFile.Image")));
             this.tsbRenameFile.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbRenameFile.Name = "tsbRenameFile";
-            this.tsbRenameFile.Size = new System.Drawing.Size(34, 41);
+            this.tsbRenameFile.Size = new System.Drawing.Size(23, 22);
             this.tsbRenameFile.Text = "Change the name of the current connection file";
             this.tsbRenameFile.Click += new System.EventHandler(this.tsbRenameFile_Click);
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 46);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStripLabel1
             // 
             this.toolStripLabel1.Name = "toolStripLabel1";
-            this.toolStripLabel1.Size = new System.Drawing.Size(64, 41);
+            this.toolStripLabel1.Size = new System.Drawing.Size(42, 22);
             this.toolStripLabel1.Text = "Search";
             // 
             // tstSearch
             // 
             this.tstSearch.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.tstSearch.Name = "tstSearch";
-            this.tstSearch.Size = new System.Drawing.Size(180, 46);
+            this.tstSearch.Size = new System.Drawing.Size(121, 23);
             this.tstSearch.TextChanged += new System.EventHandler(this.tstSearch_TextChanged);
             // 
             // pnlFooter
@@ -353,33 +349,32 @@
             this.pnlFooter.Controls.Add(this.bCancel);
             this.pnlFooter.Controls.Add(this.bValidate);
             this.pnlFooter.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.pnlFooter.Location = new System.Drawing.Point(0, 581);
-            this.pnlFooter.Margin = new System.Windows.Forms.Padding(2);
+            this.pnlFooter.Location = new System.Drawing.Point(0, 378);
+            this.pnlFooter.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
             this.pnlFooter.Name = "pnlFooter";
-            this.pnlFooter.Size = new System.Drawing.Size(1162, 50);
+            this.pnlFooter.Size = new System.Drawing.Size(775, 32);
             this.pnlFooter.TabIndex = 5;
             // 
             // pnlMain
             // 
             this.pnlMain.Controls.Add(this.lvConnections);
             this.pnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlMain.Location = new System.Drawing.Point(0, 55);
-            this.pnlMain.Margin = new System.Windows.Forms.Padding(2);
+            this.pnlMain.Location = new System.Drawing.Point(0, 25);
+            this.pnlMain.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
             this.pnlMain.Name = "pnlMain";
-            this.pnlMain.Padding = new System.Windows.Forms.Padding(7, 6, 7, 6);
-            this.pnlMain.Size = new System.Drawing.Size(1394, 642);
+            this.pnlMain.Padding = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            this.pnlMain.Size = new System.Drawing.Size(775, 353);
             this.pnlMain.TabIndex = 6;
             // 
             // ConnectionSelector
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.bCancel;
-            this.ClientSize = new System.Drawing.Size(1162, 631);
+            this.ClientSize = new System.Drawing.Size(775, 410);
             this.Controls.Add(this.pnlMain);
             this.Controls.Add(this.pnlFooter);
             this.Controls.Add(this.menu);
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "ConnectionSelector";
             this.ShowIcon = false;
             this.Text = "Connection Manager";

--- a/McTools.Xrm.Connection.WinForms/ConnectionSelector.resx
+++ b/McTools.Xrm.Connection.WinForms/ConnectionSelector.resx
@@ -124,7 +124,7 @@
   <data name="tsbNewConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIkSURBVDhPhVPbT5JhHP79Jd100U133XZjrnWwrrphq4u2
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIkSURBVDhPhVPbT5JhHP79Jd100U133XZjrnWwrrphq4u2
         LlqnOWf1zbVVaBzkkHVRoEsh6LABzXQJRLnBQKaAoOVEIPZFU2OLgLRWrban9+f3CeVIn+3Zs+d3fN/v
         QJvotXt8vTYftDZvg+w5rpb8HzdsHp9zYgqBZA7+xBImBFnZc5zzamlrXLv7BOs/f6O2/gPVtSbZc5zz
         amlr9Aw8RkUU+xN5wRwCqrLnOOfV0taQrC6U69+QyFeQKgi++7yh7DnOebW0Na5YXFiurEE34ofBGYBR
@@ -139,7 +139,7 @@
   <data name="tsbUpdateConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAI4SURBVDhPfZLLT5NREMX7N7gxLgmJLmRjjCtdaOLGuDNx
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAI4SURBVDhPfZLLT5NREMX7N7gxLgmJLmRjjCtdaOLGuDNx
         7UKjAqJB03xBVB6lpa0QIgtolEIpCoZWG0JoERcUkSIfWHmIUF4lPLRRHrUEH4nJzztQQWLrSU4mZ2bO
         mbu4hj8odbR6S2u9lNR6diha+smV9CiqbfW6OvoIDEbw65N0KEoVLX2ZJ1dTo/BBMxs/f7G+8YO1xC5F
         S1/mydXUKKh6wopa9utTihECySpa+jJPrqaGVukmFt9En1phaFpxZnWripa+Vtn0/wBjhZullQTmej/l
@@ -155,24 +155,24 @@
   <data name="tsbCloneConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAJ5SURBVDhPfZLNTxNRFMVZqvG/ceMOQyh+JSSAFDfGRBMX
-        xpgQi6HxoyiNsMUqGzVxKxsTZaEUJUA/oC2lBZSUlidpKe1MgXbm0dbOTOd431DYFDzJyVvMfb+597zb
-        0uEMTvS6I9G+kQizjy4mhftGFpOdw6HYpUH/w9bbM2da/qcb7lBM1/WkxHUmk/OqzjIFjWVUjY14Zdbj
-        Xn5/4d6Xc43yZtlfhTcKdNGfOvRcqsYmVznjNZ350hrz/Ciwy8/mhxrlzeoaXkyWCBBJkzMCorHpBGcp
-        ibMC1xj/q7M7b5dSjfJmCYBCgBW6HCcLkI+6+DAvY3xmB6+925YffIyX776LVW69CW+0OX3PL/Z/OnsM
-        UAmwRpeFBSREXYz/zMIEIPE6ZHJeNZApasipGka9Mnrd0a+t9yfOH49wBBAWo3jor3tlE35mILilg7LB
-        5GoZvGaCsoFndhdXnsx5jkdISDpLyoengIi2SxUTS2kDSxkDC380TCeq2JTKoGxA2aDHNWVaAPEKJwGU
-        qomVrIH4tgHKBr7NGrzrFXyOc2zTODdd0wRwRVhGKTQBxgigVoFfOdNyPFtHaEuDj9WsTnJqHX0C0Pk0
-        uCo6yCu0PCWNSQotFC3T2BSNYAGA37k61nbqiFEn4YzIQ0Oem7ALwDVn4Pt150LU5ghstj8KrB252x2i
-        EYCEBCTlw3OdYCtZIJyG9a3X5TWtpzxJ3cMRfb+snwooVnQCUAenqeflMnJK8VRAXi3C/iKKRnmzrg4G
-        93a5AcoGuZIGygaUjeUCef+gjvahmVqjvFlt/fOzbQOBHdvAN9PmCHKbY4EsziDvGPAftDvm8l2PQ8o/
-        UluisK9UpfwAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJ6SURBVDhPfZLNTxNRFMVZqvG/ceMOgxS/EhJAihtjookL
+        Y0yIxdD4UZRG2GKVjZq4lY2JkhgoSoB+QFtKCygpLU/SUtqZAu3Mo8XOTOd431DYFDzJyVvMfb+597zb
+        1OYMjnW7I9GeoQizDy8khXuGFpLtg6HYpX7/o+Y702ea/qeb7lBM1/WkxHUmk/OqzjIFjWVUjQ15Zdbl
+        Xvpw4f7Xc/XyRtlfh9cLdNGfOvRsqsrGVzjjVZ350hrz/CiwK8/nBurljeoYXEiWCBBJkzMCorGpBGcp
+        ibMC1xj/q7O77xZT9fJGCYBCgGW6HCcLkI+6+DgnY3R6G2+8W5YffoqX772PVW6/Da+3OH0vLvZ+PnsM
+        UAmwSpeFBSREXYz+zMIEIPEaZHJeNZApasipGoa9Mrrd0W/ND8bOH49wBBAWo3jor7tlE35mILipg7LB
+        +EoZvGqCsoFnZgdXn856jkdISDpLyoengIi2SxUTi2kDixkD8380TCUOsCGVQdmAskGXa8K0AOIVTgIo
+        ByaWswbiWwYoG/g2qvCuVfAlzrFF49xyeQngirCMUmgAjBBAPQB+5UzL8WwNoU0NPla1OsmpNfQIQPuz
+        4IroIK/Q8pQ0Jim0ULRMI5M0ggUAfudqWN2uIUadhDMiDw15bsIuANedgYkbzvmozRHYaH0cWD1ypztE
+        IwAJCUjKh+cawZazQDgN61u3a9K0nvIkdQ5G9L2yfiqgWNEJQB2cpq5XS8gpxVMBebUI+8so6uWNutYf
+        3N3hBigb5EoaKBtQNpYL5L39Gi4PTFfr5Y1q6Z2baekLbNv6vps2R5DbHPNkcQZ5W59/v9Uxm+94ElL+
+        AUmLoqhzbT1WAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="tsbDeleteConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAJKSURBVDhPhVPdS1NxGD5/QHQRdFWbWDcVFpVQKn0g3QXd
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJKSURBVDhPhVPdS1NxGD5/QHQRdFWbWDcVFpVQKn0g3QXd
         VBfRhSVG9GGZpo0oKDV1TmdF5Nanc2bQ3Gku2kcLwaETt8amGc1t2TRWLJrb2Ag0a0/vbzu5FksfeHh4
         3s/zHs7h/qBBqdE2KLSoV/QtknkWF0r+j2sKjVZlsMH0xgujYxIGIlPmWZzlhdLcuHL7KRLzPxFNzCES
         z5B5Fmd5oTQ3Lt/sRZiKjQ4f0QuToMyzOMsLpbkhkasRin2HwxeG00/8MJtS5lmc5YXS3KhrVyMYjqPp
@@ -188,7 +188,7 @@
   <data name="tsbUpdatePassword.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIMSURBVDhPjZFfS1NxHMb3OgLfgtuYkqnbJArKNnfhRRFl
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIMSURBVDhPjZFfS1NxHMb3OgLfgtuYkqnbJArKNnfhRRFl
         EJQk1dIzt+Wq/ZHoJggksjXpDXQTuh23kyFRhrjtDBPJf5V5UV10YWBr07N9+m0uWeJWH3j4cc55nu+f
         89PVQxm2hJSABSVgRQlaeRGyMjXcEap8ro/ib/mihjvJqr2weh0+OMkvXGH+aReJ4Y6vFdvBKP72kBo+
         JYL9FJacbM5eJi2eM0/s/FRLRRz1J4n7WsgtONGWJQorEqnRTsRrU0mZiJ2d91J5nbL5IKYCraK7C23J
@@ -203,7 +203,7 @@
   <data name="tsb_UseMru.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAJhSURBVDhPY6AJ4FilJKe6z6LdZq7HdJ+iwJLQ0NCksLCw
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJhSURBVDhPY6AJ4FilJKe6z6LdZq7HdJ+iwJLQ0NCksLCw
         YCAw9/Pz44Uqww44V0gHm570fpC4s+D+6cuX7z998+YHCIPY0+bPX5WYmJgZFBSkAVWOBuYJ+xqe8Xih
         tS/sz4Und/6//vjx/76DB8E0CN9+/vz/rjNnHqdlZFRgGjJHWEpklcop16th/8sOtf1/+eEDWFNPTw/c
         AJDYhQcP/h8CGhITF5fj4eHBB9UNBFMEctSPm7833un8f+21nXBNLS0tcDYI33r27P+5+/f/T507d42X
@@ -219,7 +219,7 @@
   <data name="tsbRemoveConnectionList.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAKDSURBVDhPjZHrS5NhGMb3h0QSBEEEUgpas3ncnCfMZQrV
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAKDSURBVDhPjZHrS5NhGMb3h0QSBEEEUgpas3ncnCfMZQrV
         RMgM/GBadELQPAWWaRHVB+1r2zzQdLhNsciUTmpIk1TQSrd5nukyz/brebcpLoW64OJ+7ofn+j3Pe7+y
         iBJLc2SJFVE5WWQmrLAF+R6W9hW3LdK5ZtlOSeHXkxtoHr/ly/wmtrl1Prt22za3waAbFMUWfFGvwovN
         NH1bJqG6i+6pFXLbnORYHVyyCJu9Vepz28bpnV0jrKhlN0A39Iu4qk5ejS6T1eJkL0n7HY5V8Zl/ASIE
@@ -236,7 +236,7 @@
   <data name="tsbMoveToNewFile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAJdSURBVDhPjZHdT5JhGMafv6Sj/oMOVdQS0tlWIemKLw9c
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJdSURBVDhPjZHdT5JhGMafv6Sj/oMOVdQS0tlWIemKLw9c
         bbRxoG10BAna1kJxc31sKa2TQHSlOHiRvmQws0mtCavcWqZ8Kh8JUZjZru4H0CDd6tqu3bufvdfvfp77
         ZU1Gwdls9IAqGgxu1OtdqDvE/Fx0TeDfOVm1eHg+uQvprQW82/qFUPYnljMHHcru4kMeEPULqETLaux3
         Y2a1iHZLAEsb29B6Y9B4orgkkN3lynutN47X6R3UG1wHAbaVb2gb9uP5WhE9rhgOEz/3RX/QM/8CNBFg
@@ -252,7 +252,7 @@
   <data name="tsbMoveToExistingFile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAJ1SURBVDhPlZHtS1NxGIaffyXpP+ibb9O512aKk4oKS0gK
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJ1SURBVDhPlZHtS1NxGIaffyXpP+ibb9O512aKk4oKS0gK
         DPbBL/WhnJtT8iUVJLQotAjnNqWc7E2mpBtqiaJpvmGoONciN5ZtbEvj7tnZGi2F6IGLh9/h3Nc55z5U
         pHdYi/VO8EaB1o78ehvyTiF5vbDBkbzPSn9OMvw2cAz142mshn9iOXSED8GTLIeOsX4IFOocSEdTI9LZ
         MbIdg6rTi7kvcWjG9lHr9OG2g7GndvKsGfNj/uAH8rW2kwLjRhTKDg8mdmOose3jtElen/Ql+DP/EhSx
@@ -269,7 +269,7 @@
   <data name="tsbRenameFile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAKCSURBVDhPjZHbS9NRAMf3J0T0GvXgS1kvFVFo5j3FcDWt
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAKCSURBVDhPjZHbS9NRAMf3J0T0GvXgS1kvFVFo5j3FcDWt
         IEl6kEwDH+pBE5u6zbxg2p0gfenBzc1MZ+63pLwwUcuS8B6JpZvl5iVdmlrGp/PbZrk06AtfDudwPp/D
         OUcRqpHMYRorYuRIroVgdSNBm1ReD8mT5H1mxfrIcOvkKqp7HQzO/aRv9ge9MxvbN7vKsBtC8iV8qDdH
         8y3Uf1girrydbucyGU0TpFsdpEqiFu8ozzOaPvFm+jtBuY0bBfp3i8SW2WgeWyKlcYLNIq+3OpY59Lcg

--- a/McTools.Xrm.Connection.WinForms/CustomControls/ConnectionAzureKeyVaultControl.Designer.cs
+++ b/McTools.Xrm.Connection.WinForms/CustomControls/ConnectionAzureKeyVaultControl.Designer.cs
@@ -1,0 +1,155 @@
+﻿namespace McTools.Xrm.Connection.WinForms.CustomControls
+{
+    partial class ConnectionAzureKeyVaultControl
+    {
+        /// <summary> 
+        /// Variable nécessaire au concepteur.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Nettoyage des ressources utilisées.
+        /// </summary>
+        /// <param name="disposing">true si les ressources managées doivent être supprimées ; sinon, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Code généré par le Concepteur de composants
+
+        /// <summary> 
+        /// Méthode requise pour la prise en charge du concepteur - ne modifiez pas 
+        /// le contenu de cette méthode avec l'éditeur de code.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblOauthDesc = new System.Windows.Forms.Label();
+            this.llMoreInfo = new System.Windows.Forms.LinkLabel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.txtAzureKeyVaultName = new System.Windows.Forms.TextBox();
+            this.lblClientId = new System.Windows.Forms.Label();
+            this.txtAzureAdAppId = new System.Windows.Forms.TextBox();
+            this.lblAzureKeyVaultName = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // lblOauthDesc
+            // 
+            this.lblOauthDesc.AutoSize = true;
+            this.lblOauthDesc.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lblOauthDesc.Location = new System.Drawing.Point(0, 0);
+            this.lblOauthDesc.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblOauthDesc.Name = "lblOauthDesc";
+            this.lblOauthDesc.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
+            this.lblOauthDesc.Size = new System.Drawing.Size(409, 23);
+            this.lblOauthDesc.TabIndex = 7;
+            this.lblOauthDesc.Text = "Enter a Client ID, along with the details of the Key Vault where the Client Secre" +
+    "t exists";
+            // 
+            // llMoreInfo
+            // 
+            this.llMoreInfo.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.llMoreInfo.Location = new System.Drawing.Point(0, 130);
+            this.llMoreInfo.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.llMoreInfo.Name = "llMoreInfo";
+            this.llMoreInfo.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
+            this.llMoreInfo.Size = new System.Drawing.Size(491, 18);
+            this.llMoreInfo.TabIndex = 3;
+            this.llMoreInfo.TabStop = true;
+            this.llMoreInfo.Text = "Show me how to create an Azure AD application";
+            this.llMoreInfo.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.llMoreInfo_LinkClicked);
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 164F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.txtAzureKeyVaultName, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblClientId, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.txtAzureAdAppId, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblAzureKeyVaultName, 0, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 23);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(491, 107);
+            this.tableLayoutPanel1.TabIndex = 15;
+            // 
+            // txtAzureKeyVaultName
+            // 
+            this.txtAzureKeyVaultName.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtAzureKeyVaultName.Location = new System.Drawing.Point(166, 28);
+            this.txtAzureKeyVaultName.Margin = new System.Windows.Forms.Padding(2, 4, 2, 2);
+            this.txtAzureKeyVaultName.Name = "txtAzureKeyVaultName";
+            this.txtAzureKeyVaultName.Size = new System.Drawing.Size(326, 20);
+            this.txtAzureKeyVaultName.TabIndex = 16;
+            // 
+            // lblClientId
+            // 
+            this.lblClientId.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblClientId.Location = new System.Drawing.Point(2, 0);
+            this.lblClientId.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblClientId.Name = "lblClientId";
+            this.lblClientId.Size = new System.Drawing.Size(160, 24);
+            this.lblClientId.TabIndex = 11;
+            this.lblClientId.Text = "Client Id";
+            this.lblClientId.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // txtAzureAdAppId
+            // 
+            this.txtAzureAdAppId.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtAzureAdAppId.Location = new System.Drawing.Point(166, 5);
+            this.txtAzureAdAppId.Margin = new System.Windows.Forms.Padding(2, 5, 2, 2);
+            this.txtAzureAdAppId.Name = "txtAzureAdAppId";
+            this.txtAzureAdAppId.Size = new System.Drawing.Size(326, 20);
+            this.txtAzureAdAppId.TabIndex = 1;
+            // 
+            // lblAzureKeyVaultName
+            // 
+            this.lblAzureKeyVaultName.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblAzureKeyVaultName.Location = new System.Drawing.Point(2, 24);
+            this.lblAzureKeyVaultName.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblAzureKeyVaultName.Name = "lblAzureKeyVaultName";
+            this.lblAzureKeyVaultName.Size = new System.Drawing.Size(160, 24);
+            this.lblAzureKeyVaultName.TabIndex = 15;
+            this.lblAzureKeyVaultName.Text = "Azure Key Vault Name";
+            this.lblAzureKeyVaultName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // ConnectionAzureKeyVaultControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.llMoreInfo);
+            this.Controls.Add(this.lblOauthDesc);
+            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Name = "ConnectionAzureKeyVaultControl";
+            this.Size = new System.Drawing.Size(491, 148);
+            this.Load += new System.EventHandler(this.ConnectionOauthControl_Load);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.Label lblOauthDesc;
+        private System.Windows.Forms.LinkLabel llMoreInfo;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label lblClientId;
+        private System.Windows.Forms.TextBox txtAzureAdAppId;
+        private System.Windows.Forms.TextBox txtAzureKeyVaultName;
+        private System.Windows.Forms.Label lblAzureKeyVaultName;
+    }
+}

--- a/McTools.Xrm.Connection.WinForms/CustomControls/ConnectionAzureKeyVaultControl.cs
+++ b/McTools.Xrm.Connection.WinForms/CustomControls/ConnectionAzureKeyVaultControl.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace McTools.Xrm.Connection.WinForms.CustomControls
+{
+    public partial class ConnectionAzureKeyVaultControl : UserControl, IConnectionWizardControl
+    {
+        public ConnectionAzureKeyVaultControl()
+        {
+            InitializeComponent();
+        }
+
+        public Guid AzureAdAppId
+        {
+            get
+            {
+                if (!Guid.TryParse(txtAzureAdAppId.Text, out Guid id))
+                {
+                    MessageBox.Show(this, @"The Azure AD Application Id is not a valid GUID!", @"Error",
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+                    return Guid.Empty;
+                }
+
+                return id;
+            }
+            set => txtAzureAdAppId.Text = value.ToString();
+        }
+
+
+        public string AzureKeyVaultName
+        {
+            get
+            {
+                return txtAzureKeyVaultName.Text;
+            }
+            set => txtAzureKeyVaultName.Text = value;
+        }
+
+        private void ConnectionOauthControl_Load(object sender, EventArgs e)
+        {
+            txtAzureAdAppId.Focus();
+
+        }
+
+        private void llMoreInfo_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start($"https://docs.microsoft.com/{CultureInfo.CurrentUICulture.Name}/dynamics365/customer-engagement/developer/walkthrough-register-dynamics-365-app-azure-active-directory");
+        }
+    }
+}

--- a/McTools.Xrm.Connection.WinForms/CustomControls/ConnectionAzureKeyVaultControl.resx
+++ b/McTools.Xrm.Connection.WinForms/CustomControls/ConnectionAzureKeyVaultControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/McTools.Xrm.Connection.WinForms/CustomControls/StartPageControl.Designer.cs
+++ b/McTools.Xrm.Connection.WinForms/CustomControls/StartPageControl.Designer.cs
@@ -32,6 +32,7 @@
             this.btnSdkLoginControl = new System.Windows.Forms.Button();
             this.btnConnectionString = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.btnAzureKeyVault = new System.Windows.Forms.Button();
             this.btnMfa = new System.Windows.Forms.Button();
             this.btnClientSecret = new System.Windows.Forms.Button();
             this.btnCertificate = new System.Windows.Forms.Button();
@@ -44,11 +45,11 @@
             this.btnStandard.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnStandard.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.connection_wizard_32;
             this.btnStandard.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnStandard.Location = new System.Drawing.Point(8, 8);
-            this.btnStandard.Margin = new System.Windows.Forms.Padding(8);
+            this.btnStandard.Location = new System.Drawing.Point(5, 5);
+            this.btnStandard.Margin = new System.Windows.Forms.Padding(5);
             this.btnStandard.Name = "btnStandard";
-            this.btnStandard.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.btnStandard.Size = new System.Drawing.Size(290, 47);
+            this.btnStandard.Padding = new System.Windows.Forms.Padding(7, 0, 0, 0);
+            this.btnStandard.Size = new System.Drawing.Size(194, 30);
             this.btnStandard.TabIndex = 0;
             this.btnStandard.Text = "Connection Wizard";
             this.btnStandard.UseVisualStyleBackColor = true;
@@ -61,11 +62,11 @@
             this.btnSdkLoginControl.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnSdkLoginControl.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.Dataverse_32x32;
             this.btnSdkLoginControl.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnSdkLoginControl.Location = new System.Drawing.Point(314, 8);
-            this.btnSdkLoginControl.Margin = new System.Windows.Forms.Padding(8);
+            this.btnSdkLoginControl.Location = new System.Drawing.Point(209, 5);
+            this.btnSdkLoginControl.Margin = new System.Windows.Forms.Padding(5);
             this.btnSdkLoginControl.Name = "btnSdkLoginControl";
-            this.btnSdkLoginControl.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.btnSdkLoginControl.Size = new System.Drawing.Size(291, 47);
+            this.btnSdkLoginControl.Padding = new System.Windows.Forms.Padding(7, 0, 0, 0);
+            this.btnSdkLoginControl.Size = new System.Drawing.Size(195, 30);
             this.btnSdkLoginControl.TabIndex = 1;
             this.btnSdkLoginControl.Text = "Microsoft Login Control";
             this.btnSdkLoginControl.UseVisualStyleBackColor = true;
@@ -78,11 +79,11 @@
             this.btnConnectionString.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.btnConnectionString.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.connection_string_32;
             this.btnConnectionString.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnConnectionString.Location = new System.Drawing.Point(314, 71);
-            this.btnConnectionString.Margin = new System.Windows.Forms.Padding(8);
+            this.btnConnectionString.Location = new System.Drawing.Point(209, 45);
+            this.btnConnectionString.Margin = new System.Windows.Forms.Padding(5);
             this.btnConnectionString.Name = "btnConnectionString";
-            this.btnConnectionString.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.btnConnectionString.Size = new System.Drawing.Size(291, 47);
+            this.btnConnectionString.Padding = new System.Windows.Forms.Padding(7, 0, 0, 0);
+            this.btnConnectionString.Size = new System.Drawing.Size(195, 30);
             this.btnConnectionString.TabIndex = 2;
             this.btnConnectionString.Text = "Connection String";
             this.btnConnectionString.UseVisualStyleBackColor = true;
@@ -93,7 +94,7 @@
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 15F));
+            this.tableLayoutPanel1.Controls.Add(this.btnAzureKeyVault, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.btnMfa, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.btnClientSecret, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.btnCertificate, 0, 1);
@@ -102,14 +103,32 @@
             this.tableLayoutPanel1.Controls.Add(this.btnConnectionString, 1, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(8, 16, 8, 16);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(5, 10, 5, 10);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 3;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(613, 190);
+            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(409, 160);
             this.tableLayoutPanel1.TabIndex = 3;
+            // 
+            // btnAzureKeyVault
+            // 
+            this.btnAzureKeyVault.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.btnAzureKeyVault.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.btnAzureKeyVault.Font = new System.Drawing.Font("Segoe UI", 10F);
+            this.btnAzureKeyVault.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.connection_secret_32;
+            this.btnAzureKeyVault.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btnAzureKeyVault.Location = new System.Drawing.Point(5, 125);
+            this.btnAzureKeyVault.Margin = new System.Windows.Forms.Padding(5);
+            this.btnAzureKeyVault.Name = "btnAzureKeyVault";
+            this.btnAzureKeyVault.Padding = new System.Windows.Forms.Padding(7, 0, 0, 0);
+            this.btnAzureKeyVault.Size = new System.Drawing.Size(194, 30);
+            this.btnAzureKeyVault.TabIndex = 6;
+            this.btnAzureKeyVault.Text = "Azure Key Vault";
+            this.btnAzureKeyVault.UseVisualStyleBackColor = true;
+            this.btnAzureKeyVault.Click += new System.EventHandler(this.btn_Click);
             // 
             // btnMfa
             // 
@@ -118,11 +137,11 @@
             this.btnMfa.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.btnMfa.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.connection_mfa_32;
             this.btnMfa.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnMfa.Location = new System.Drawing.Point(8, 134);
-            this.btnMfa.Margin = new System.Windows.Forms.Padding(8);
+            this.btnMfa.Location = new System.Drawing.Point(5, 85);
+            this.btnMfa.Margin = new System.Windows.Forms.Padding(5);
             this.btnMfa.Name = "btnMfa";
-            this.btnMfa.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.btnMfa.Size = new System.Drawing.Size(290, 48);
+            this.btnMfa.Padding = new System.Windows.Forms.Padding(7, 0, 0, 0);
+            this.btnMfa.Size = new System.Drawing.Size(194, 30);
             this.btnMfa.TabIndex = 5;
             this.btnMfa.Text = "OAuth / MFA";
             this.btnMfa.UseVisualStyleBackColor = true;
@@ -135,11 +154,11 @@
             this.btnClientSecret.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.btnClientSecret.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.connection_secret_32;
             this.btnClientSecret.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnClientSecret.Location = new System.Drawing.Point(314, 134);
-            this.btnClientSecret.Margin = new System.Windows.Forms.Padding(8);
+            this.btnClientSecret.Location = new System.Drawing.Point(209, 85);
+            this.btnClientSecret.Margin = new System.Windows.Forms.Padding(5);
             this.btnClientSecret.Name = "btnClientSecret";
-            this.btnClientSecret.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.btnClientSecret.Size = new System.Drawing.Size(291, 48);
+            this.btnClientSecret.Padding = new System.Windows.Forms.Padding(7, 0, 0, 0);
+            this.btnClientSecret.Size = new System.Drawing.Size(195, 30);
             this.btnClientSecret.TabIndex = 4;
             this.btnClientSecret.Text = "Client Id / Secret";
             this.btnClientSecret.UseVisualStyleBackColor = true;
@@ -152,11 +171,11 @@
             this.btnCertificate.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.btnCertificate.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.connection_certificate_32;
             this.btnCertificate.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnCertificate.Location = new System.Drawing.Point(8, 71);
-            this.btnCertificate.Margin = new System.Windows.Forms.Padding(8);
+            this.btnCertificate.Location = new System.Drawing.Point(5, 45);
+            this.btnCertificate.Margin = new System.Windows.Forms.Padding(5);
             this.btnCertificate.Name = "btnCertificate";
-            this.btnCertificate.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.btnCertificate.Size = new System.Drawing.Size(290, 47);
+            this.btnCertificate.Padding = new System.Windows.Forms.Padding(7, 0, 0, 0);
+            this.btnCertificate.Size = new System.Drawing.Size(194, 30);
             this.btnCertificate.TabIndex = 3;
             this.btnCertificate.Text = "Certificate";
             this.btnCertificate.UseVisualStyleBackColor = true;
@@ -164,13 +183,13 @@
             // 
             // StartPageControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(1);
             this.Name = "StartPageControl";
-            this.Size = new System.Drawing.Size(613, 190);
+            this.Size = new System.Drawing.Size(409, 160);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -185,5 +204,6 @@
         private System.Windows.Forms.Button btnCertificate;
         private System.Windows.Forms.Button btnClientSecret;
         private System.Windows.Forms.Button btnMfa;
+        private System.Windows.Forms.Button btnAzureKeyVault;
     }
 }

--- a/McTools.Xrm.Connection.WinForms/CustomControls/StartPageControl.cs
+++ b/McTools.Xrm.Connection.WinForms/CustomControls/StartPageControl.cs
@@ -10,7 +10,8 @@ namespace McTools.Xrm.Connection.WinForms.CustomControls
         ConnectionString,
         Certificate,
         ClientSecret,
-        Mfa
+        Mfa,
+        AzureKeyVault
     }
 
     public partial class StartPageControl : UserControl, IConnectionWizardControl
@@ -52,6 +53,10 @@ Connections created with this wizard cannot be transported across multiple compu
             else if (sender == btnMfa)
             {
                 Type = ConnectionType.Mfa;
+            }
+            else if (sender == btnAzureKeyVault)
+            {
+                Type = ConnectionType.AzureKeyVault;
             }
             else
             {

--- a/McTools.Xrm.Connection.WinForms/McTools.Xrm.Connection.WinForms.csproj
+++ b/McTools.Xrm.Connection.WinForms/McTools.Xrm.Connection.WinForms.csproj
@@ -60,7 +60,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>McTools.Xrm.Connection.WinForms.pfx</AssemblyOriginatorKeyFile>
@@ -128,6 +128,12 @@
     </Compile>
     <Compile Include="CRMLoginForm1.xaml.cs">
       <DependentUpon>CRMLoginForm1.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="CustomControls\ConnectionAzureKeyVaultControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CustomControls\ConnectionAzureKeyVaultControl.Designer.cs">
+      <DependentUpon>ConnectionAzureKeyVaultControl.cs</DependentUpon>
     </Compile>
     <Compile Include="CustomControls\ConnectionCredentialsControl.cs">
       <SubType>UserControl</SubType>
@@ -299,6 +305,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ConnectionWizard2.resx">
       <DependentUpon>ConnectionWizard2.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CustomControls\ConnectionAzureKeyVaultControl.resx">
+      <DependentUpon>ConnectionAzureKeyVaultControl.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CustomControls\ConnectionCredentialsControl.resx">
       <DependentUpon>ConnectionCredentialsControl.cs</DependentUpon>

--- a/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
+++ b/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
@@ -75,7 +75,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>McTools.Xrm.Connection.pfx</AssemblyOriginatorKeyFile>
@@ -163,6 +163,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity">
+      <Version>1.13.1</Version>
+    </PackageReference>
+    <PackageReference Include="Azure.Security.KeyVault.Secrets">
+      <Version>4.7.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.CrmSdk.Workflow">
       <Version>9.0.2.49</Version>
     </PackageReference>


### PR DESCRIPTION
I've added logic to allow Azure Key Vault to be used for Client Id / Client Secrets. There is an additional option when setting up a connection that will allow you to enter an Org URL, followed by the Client Id and an Azure Key Vault storage name. It's expected that the user has access to the Key Vault you specify, and that the Client Secret is stored in the Secrets area of that Azure Key Vault using the Client Id.

You may be prompted for the standard ClientId/Secret in a dialog, but this can just be left empty. A future change should be to remove this.

The primary benefit to this is not storing credentials locally, not sharing credentials directly, and being able to rotate Client Secrets without resharing/re-entering (since it calls Key Vault each time to get the latest).

**These changes were made two months ago. You'll need to re-enable the Assembly Signing as well as the reference to McTools.Xrm.Connection.AppCode**